### PR TITLE
Remove Windows credential

### DIFF
--- a/DuckDB.pq
+++ b/DuckDB.pq
@@ -171,7 +171,6 @@ DuckDB = [
             {"DuckDB.Contents", database, motherduck_token, read_only, saas_mode, attach_mode, options},
     // Set supported types of authentication
     Authentication = [
-        Windows = [],
         Anonymous = [],
         UsernamePassword = []
     ],


### PR DESCRIPTION
Now that the credentials password overrides the MotherDuck token, we want to deprecate the Windows credential to avoid confusion.